### PR TITLE
Adding "version" key

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,6 +2,7 @@
     "domain": "repsolluzygas",
     "name": "Sensor - Repsol Luz y Gas",
     "documentation": "https://github.com/bzzoiro/repsolluzygas",
+    "version": "1.0.0",
     "dependencies": [],
     "codeowners": ["@bzzoiro"],
     "requirements": ["requests"],


### PR DESCRIPTION
"Version" key will be required starting from HA 2021.6.

What about staring with version 1.0.0 as the component is working and has no known open bugs?